### PR TITLE
Add banner pointing to main repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 <p align="center">
+  <strong>⚠️ This repository is no longer actively maintained. Development has moved to <a href="https://github.com/Kilo-Org/kilocode">github.com/Kilo-Org/kilocode</a>.</strong>
+</p>
+
+<p align="center">
   <a href="https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code"><img src="https://img.shields.io/badge/VS_Code_Marketplace-007ACC?style=flat&logo=visualstudiocode&logoColor=white" alt="VS Code Marketplace"></a>
   <a href="https://x.com/kilocode"><img src="https://img.shields.io/badge/kilocode-000000?style=flat&logo=x&logoColor=white" alt="X (Twitter)"></a>
   <a href="https://blog.kilo.ai"><img src="https://img.shields.io/badge/Blog-555?style=flat&logo=substack&logoColor=white" alt="Substack Blog"></a>


### PR DESCRIPTION
Adds a banner at the top of the README indicating that this repository is no longer actively maintained and that development has moved to https://github.com/Kilo-Org/kilocode.