### PR TITLE
Pre Select Reasoning Option for Reasoning-Enabled Oracle Code Assist Models

### DIFF
--- a/src/api/providers/fetchers/oca.ts
+++ b/src/api/providers/fetchers/oca.ts
@@ -105,7 +105,7 @@ export async function getOCAModels(
 						? "chat-completions"
 						: "unknown",
 				...{ supportsReasoningEffort: info?.is_reasoning_model ? info?.reasoning_effort_options : false },
-				reasoningEffort: undefined,
+				reasoningEffort: info?.is_reasoning_model ? info?.reasoning_effort_options.includes("medium") ? "medium" : info?.reasoning_effort_options[0] : undefined
 			}
 
 			models[modelId] = baseInfo


### PR DESCRIPTION
<!--
NOTE: New versions of the VS Code extension and CLI are being developed in https://github.com/Kilo-Org/Kilo
(extension: packages/kilo-vscode, CLI: packages/opencode).
If your changes are for the extension or CLI, please open your PR in that repository instead.
-->

## Context

For OCA Handler, we previously were setting reasoning_effort to undefined by default, which produced unexpected behaviors for select models (gpt-5.3-codex was not responding with any assistant messages)


This change addresses the problem by preselecting a valid reasoning effort option instead of leaving it as undefined.


## Implementation

Change logic in fetchers/oca.ts to select "medium" from reasoning effort options (only if the model is reasoning enabled) and if not, select the first element in the reasoning effort options array.

## Screenshots

| before | after |
| ------ | ----- |
| <img width="1396" height="1356" alt="image (16)" src="https://github.com/user-attachments/assets/df3f00fe-6346-41cd-80d6-96257c8ad82a" />|<img width="963" height="964" alt="Screenshot 2026-03-11 at 3 32 16 PM" src="https://github.com/user-attachments/assets/187a5b13-3941-4bc3-8afc-6c396b1ce8b8" />|

## How to Test

With OCA model provider selected, choose a reasoning model like "oca/gpt-5.3-codex"

Do not select a reasoning option and observe that no provider errors due to missing assistant messages are produced