### PR TITLE
fix(jetbrains): use application-scoped commit message service

### DIFF
--- a/.changeset/spotty-carrots-trade.md
+++ b/.changeset/spotty-carrots-trade.md
@@ -1,0 +1,5 @@
+---
+"@kilo-code/jetbrains-plugin": patch
+---
+
+fix(jetbrains): use application-scoped commit message service

--- a/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/actions/GitCommitMessageAction.kt
+++ b/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/actions/GitCommitMessageAction.kt
@@ -100,7 +100,7 @@ class GitCommitMessageAction : AnAction(I18n.t("kilocode:commitMessage.ui.genera
 
                     indicator.text = I18n.t("kilocode:commitMessage.progress.generating")
                     val result = runBlocking {
-                        CommitMessageService.getInstance(project).generateCommitMessage(project, workspacePath, files.ifEmpty { null })
+                        CommitMessageService.getInstance().generateCommitMessage(project, workspacePath, files.ifEmpty { null })
                     }
 
                     ApplicationManager.getApplication().invokeLater {
@@ -152,7 +152,7 @@ class GitCommitMessageAction : AnAction(I18n.t("kilocode:commitMessage.ui.genera
 
                     indicator.text = I18n.t("kilocode:commitMessage.progress.generating")
                     val result = runBlocking {
-                        CommitMessageService.getInstance(project).generateCommitMessage(project, workspacePath, files.ifEmpty { null })
+                        CommitMessageService.getInstance().generateCommitMessage(project, workspacePath, files.ifEmpty { null })
                     }
 
                     ApplicationManager.getApplication().invokeLater {

--- a/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/git/CommitMessageHandler.kt
+++ b/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/git/CommitMessageHandler.kt
@@ -43,7 +43,7 @@ class CommitMessageHandler(
 ) : CheckinHandler() {
 
     private val logger: Logger = Logger.getInstance(CommitMessageHandler::class.java)
-    private val commitMessageService by lazy { CommitMessageService.getInstance(panel.project) }
+    private val commitMessageService by lazy { CommitMessageService.getInstance() }
     private val fileDiscoveryService = FileDiscoveryService()
 
     private lateinit var generateButton: JButton

--- a/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/git/CommitMessageService.kt
+++ b/jetbrains/plugin/src/main/kotlin/ai/kilocode/jetbrains/git/CommitMessageService.kt
@@ -128,11 +128,10 @@ class CommitMessageService {
 
     companion object {
         /**
-         * Gets or creates the CommitMessageService instance for the project.
-         * @param project The project context for which to get the service
+         * Gets the application-level CommitMessageService instance.
          */
-        fun getInstance(project: Project): CommitMessageService {
-            return project.getService(CommitMessageService::class.java)
+        fun getInstance(): CommitMessageService {
+            return ApplicationManager.getApplication().getService(CommitMessageService::class.java)
         }
     }
 }


### PR DESCRIPTION
<!-- kilocode_change - new file -->
<!--
NOTE: New versions of the VS Code extension and CLI are being developed in https://github.com/Kilo-Org/Kilo
(extension: packages/kilo-vscode, CLI: packages/opencode).
If your changes are for the extension or CLI, please open your PR in that repository instead.
-->

## Context
Fixes [#9956](https://github.com/Kilo-Org/kilocode/issues/9956)
Fix the JetBrains commit message generator service lookup. It was registered as an application service but retrieved as a project service, which caused runtime errors when generating commit messages.

## Implementation

Updated `CommitMessageService` to resolve from `ApplicationManager` and removed the unused `project` parameter from `getInstance()`. Adjusted the JetBrains action and handler call sites to use the new application-scoped accessor.

## How to Test

- Install or run the JetBrains plugin build containing this change.
- Open a git-backed project in IntelliJ.
- Trigger `Generate Commit Message` from the commit flow.
- Confirm no `registered as application service, but requested as project one` error appears.

# Demo
Issue was successfully reproduced in the latest release: **Version: 5.16.0 (af8f0a17)**

https://github.com/user-attachments/assets/94646f67-7f7c-4fa4-9ce8-8bb8d5dac28d

Fix version:  https://github.com/Kilo-Org/kilocode-legacy/pull/140/changes/37013a42c59b34c36a00c385b65ef508973e0b05

https://github.com/user-attachments/assets/67e5128f-93c6-4475-8503-61fa189a12ed

## Get in Touch

Discord: `hdcodedev`