### PR TITLE
Fix ripgrep resolution for newer VS Code

### DIFF
--- a/.changeset/fix-universal-ripgrep.md
+++ b/.changeset/fix-universal-ripgrep.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix file search and indexing on newer VS Code versions.

--- a/src/services/ripgrep/index.ts
+++ b/src/services/ripgrep/index.ts
@@ -90,7 +90,15 @@ export async function getBinPath(vscodeAppRoot: string): Promise<string | undefi
 		return (await fileExistsAtPath(fullPath)) ? fullPath : undefined
 	}
 
+	// kilocode_change start
+	const universalBinFolder = `bin/${process.platform}-${process.arch}`
+	// kilocode_change end
+
 	return (
+		// kilocode_change start
+		(await checkPath(`node_modules/@vscode/ripgrep-universal/${universalBinFolder}`)) ||
+		(await checkPath(`node_modules.asar.unpacked/@vscode/ripgrep-universal/${universalBinFolder}`)) ||
+		// kilocode_change end
 		(await checkPath("node_modules/@vscode/ripgrep/bin/")) ||
 		(await checkPath("node_modules/vscode-ripgrep/bin")) ||
 		(await checkPath("node_modules.asar.unpacked/vscode-ripgrep/bin/")) ||


### PR DESCRIPTION
## Summary

Latest VSCode 1.122 moved the ripgrep binary. This PR fixes the location we look for ripgrep in to allow the extension to function.

- resolve the platform-specific `@vscode/ripgrep-universal` binary bundled with VS Code 1.122+
- support both regular and ASAR-unpacked VS Code layouts while preserving legacy fallbacks
- add a patch changeset for restored file search and indexing

## Validation
- Manual validation
- `pnpm test services/ripgrep/__tests__/index.spec.ts`
- `pnpm test` from `src` (527 files, 8,051 tests passed)
- `pnpm check-types`
- `pnpm lint`
- launched the extension development host with VS Code 1.122.1