### PR TITLE
feat(fireworks): add GLM 5.1 and GLM 5.2 models

### DIFF
--- a/packages/types/src/providers/fireworks.ts
+++ b/packages/types/src/providers/fireworks.ts
@@ -20,6 +20,8 @@ export type FireworksModelId =
 	| "accounts/fireworks/models/glm-4p5-air"
 	| "accounts/fireworks/models/glm-4p6"
 	| "accounts/fireworks/models/glm-4p7"
+	| "accounts/fireworks/models/glm-5p1"
+	| "accounts/fireworks/models/glm-5p2"
 	| "accounts/fireworks/models/gpt-oss-20b"
 	| "accounts/fireworks/models/gpt-oss-120b"
 
@@ -248,6 +250,40 @@ export const fireworksModels = {
 		outputPrice: 2.2,
 		cacheReadsPrice: 0.3,
 		displayName: "GLM-4.7",
+	},
+	"accounts/fireworks/models/glm-5p1": {
+		maxTokens: 131072,
+		contextWindow: 202800,
+		supportsImages: false,
+		supportsPromptCache: true,
+		supportsNativeTools: true,
+		supportsReasoningEffort: ["disable", "high", "max"],
+		reasoningEffort: "high",
+		preserveReasoning: true,
+		inputPrice: 1.4,
+		outputPrice: 4.4,
+		cacheReadsPrice: 0.26,
+		displayName: "GLM 5.1",
+		description:
+			"GLM-5.1 is Zhipu's coding-focused model with built-in reasoning, 202k context, and dual thinking-effort modes (High/Max).",
+	},
+	"accounts/fireworks/models/glm-5p2": {
+		maxTokens: 131072,
+		contextWindow: 1000000,
+		supportsImages: false,
+		supportsPromptCache: true,
+		supportsNativeTools: true,
+		supportsMaxTokens: true,
+		supportsReasoningEffort: ["disable", "high", "max"],
+		reasoningEffort: "high",
+		preserveReasoning: true,
+		inputPrice: 1.4,
+		outputPrice: 4.4,
+		cacheWritesPrice: 0,
+		cacheReadsPrice: 0.26,
+		displayName: "GLM 5.2",
+		description:
+			"GLM-5.2 is Zhipu's flagship model with a 1M context window, 128k max output, and dual thinking-effort modes (High/Max). It delivers top-tier long-context reasoning, coding, and agentic performance.",
 	},
 	"accounts/fireworks/models/gpt-oss-20b": {
 		maxTokens: 128_000,

--- a/src/api/providers/__tests__/fireworks.spec.ts
+++ b/src/api/providers/__tests__/fireworks.spec.ts
@@ -260,6 +260,42 @@ describe("FireworksHandler", () => {
 		expect(model.info).toEqual(expect.objectContaining(fireworksModels[testModelId]))
 	})
 
+	it("should return GLM 5.1 model with correct configuration", () => {
+		const testModelId: FireworksModelId = "accounts/fireworks/models/glm-5p1"
+		const handlerWithModel = new FireworksHandler({
+			apiModelId: testModelId,
+			fireworksApiKey: "test-fireworks-api-key",
+		})
+		const model = handlerWithModel.getModel()
+		expect(model.id).toBe(testModelId)
+		expect(model.info).toEqual(expect.objectContaining(fireworksModels[testModelId]))
+	})
+
+	it("should return GLM 5.2 model with correct configuration", () => {
+		const testModelId: FireworksModelId = "accounts/fireworks/models/glm-5p2"
+		const handlerWithModel = new FireworksHandler({
+			apiModelId: testModelId,
+			fireworksApiKey: "test-fireworks-api-key",
+		})
+		const model = handlerWithModel.getModel()
+		expect(model.id).toBe(testModelId)
+		expect(model.info).toEqual(
+			expect.objectContaining({
+				maxTokens: 131072,
+				contextWindow: 1000000,
+				supportsImages: false,
+				supportsPromptCache: true,
+				supportsMaxTokens: true,
+				supportsReasoningEffort: ["disable", "high", "max"],
+				reasoningEffort: "high",
+				preserveReasoning: true,
+				inputPrice: 1.4,
+				outputPrice: 4.4,
+				cacheReadsPrice: 0.26,
+			}),
+		)
+	})
+
 	it("should return Kimi K2.6 model with correct configuration", () => {
 		const testModelId: FireworksModelId = "accounts/fireworks/models/kimi-k2p6"
 		const handlerWithModel = new FireworksHandler({


### PR DESCRIPTION
## Summary

Adds GLM 5.1 (\ccounts/fireworks/models/glm-5p1\) and GLM 5.2 (\ccounts/fireworks/models/glm-5p2\) to the Fireworks AI provider.

### GLM 5.1
- Context: 202,800 tokens
- Max output: 131,072 tokens
- Reasoning effort: disable / high / max
- Prompt cache: supported (\.26/M cached reads)
- Pricing: \.40/M input, \.40/M output

### GLM 5.2
- Context: 1,000,000 tokens (1M)
- Max output: 131,072 tokens
- Reasoning effort: disable / high / max
- Prompt cache: supported (\.26/M cached reads)
- Pricing: \.40/M input, \.40/M output
- Supports \maxTokens\ override

Source: https://app.fireworks.ai/models/fireworks/glm-5p2

## Changed files
- \packages/types/src/providers/fireworks.ts\ — added type IDs + model configs
- \src/api/providers/__tests__/fireworks.spec.ts\ — added test cases for both models

## How to test
1. Open Settings → Providers → Fireworks
2. Select \GLM 5.2\ from the model dropdown
3. Verify model loads and responds correctly