### PR TITLE
Fix legacy docs support links

### DIFF
--- a/docs/legacy-ides/ai-providers/inception.md
+++ b/docs/legacy-ides/ai-providers/inception.md
@@ -29,4 +29,4 @@ Refer to Inception's current website and developer documentation for the most up
 - **Enterprise Focus:** Inception is designed for production-grade AI applications with emphasis on reliability and consistency.
 - **Pricing:** Refer to the Inception platform for current pricing details and available subscription options.
 - **Support:** Enterprise customers have access to dedicated support channels for technical assistance.
-- **Docs Feedback:** Report documentation issues at [Kilo-Org/kilocode issues](https://github.com/Kilo-Org/kilocode/issues/new?title=Documentation%20Issue:%20/docs/ai-providers/inception).
+- **Docs Feedback:** Report documentation issues at [Kilo-Org/kilocode-legacy issues](https://github.com/Kilo-Org/kilocode-legacy/issues/new?title=Documentation%20Issue:%20/docs/ai-providers/inception).

--- a/docs/legacy-ides/ai-providers/zenmux.md
+++ b/docs/legacy-ides/ai-providers/zenmux.md
@@ -188,4 +188,4 @@ For additional support:
 
 - Visit the [ZenMux documentation](https://zenmux.ai/docs)
 - Contact ZenMux support through their dashboard
-- Check the [Kilo Code GitHub repository](https://github.com/Kilo-Org/kilocode) for integration-specific issues
+- Check the [Kilo Code legacy GitHub repository](https://github.com/Kilo-Org/kilocode-legacy) for integration-specific issues

--- a/docs/legacy-ides/automate/extending/shell-integration.md
+++ b/docs/legacy-ides/automate/extending/shell-integration.md
@@ -350,7 +350,7 @@ The [VS Code Terminal Integration Test Extension](https://github.com/KJ7LNW/vsce
 
 If you've followed these steps and are still experiencing problems, please:
 
-1. Check the [Kilo Code GitHub Issues](https://github.com/Kilo-Org/kilocode/issues) to see if others have reported similar problems
+1. Check the [Kilo Code Legacy GitHub Issues](https://github.com/Kilo-Org/kilocode-legacy/issues) to see if others have reported similar problems
 2. If not, create a new issue with details about your operating system, VS Code/Cursor version, and the steps you've tried
 
 For additional help, join our [Discord](https://kilo.ai/discord).

--- a/docs/legacy-ides/customize/custom-modes.md
+++ b/docs/legacy-ides/customize/custom-modes.md
@@ -506,4 +506,4 @@ customModes:
 
 ## Community Gallery
 
-Ready to explore more? Check out the [Show and Tell](https://github.com/Kilo-Org/kilocode/discussions/categories/show-and-tell) to discover and share custom modes and agents created by the community!
+Ready to explore more? Check out the [legacy Show and Tell](https://github.com/Kilo-Org/kilocode-legacy/discussions/categories/show-and-tell) to discover and share custom modes and agents created by the community!

--- a/docs/legacy-ides/getting-started/installing.md
+++ b/docs/legacy-ides/getting-started/installing.md
@@ -48,5 +48,5 @@ After installation, check out these resources to get started:
 If you encounter issues not covered here:
 
 - Join our [Discord community](https://kilo.ai/discord) for real-time support
-- Submit issues on [GitHub](https://github.com/Kilo-Org/kilocode/issues)
+- Submit issues on [GitHub](https://github.com/Kilo-Org/kilocode-legacy/issues)
 - Visit our [Reddit community](https://www.reddit.com/r/KiloCode)


### PR DESCRIPTION
## Summary

- Point legacy IDE docs support, issue, and discussion links at `Kilo-Org/kilocode-legacy` instead of the current product repo.
- Verified there are no remaining `Kilo-Org/kilocode` references under `docs/legacy-ides`.

## Testing

- `git grep` equivalent via repo search for `github.com/Kilo-Org/kilocode` and `Kilo-Org/kilocode` under `docs/legacy-ides`
- Pre-commit hook ran `prettier --write` and `pnpm lint` successfully
